### PR TITLE
Add EIP-6963 wallet support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { Web3ContextProvider } from './providers/Web3Provider'
 import { ConnectWallet } from './pages/ConnectWallet'
 import { WrapFormContextProvider } from './providers/WrapFormProvider'
 import { Transaction } from './pages/Transaction'
+import { EIP1193ContextProvider } from './providers/EIP1193Provider.tsx'
 
 const router = createHashRouter([
   {
@@ -33,7 +34,9 @@ const router = createHashRouter([
 ])
 
 export const App: FC = () => (
-  <Web3ContextProvider>
-    <RouterProvider router={router} />
-  </Web3ContextProvider>
+  <EIP1193ContextProvider>
+    <Web3ContextProvider>
+      <RouterProvider router={router} />
+    </Web3ContextProvider>
+  </EIP1193ContextProvider>
 )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,8 @@ import { ConnectWallet } from './pages/ConnectWallet'
 import { WrapFormContextProvider } from './providers/WrapFormProvider'
 import { Transaction } from './pages/Transaction'
 import { EIP1193ContextProvider } from './providers/EIP1193Provider.tsx'
+import { EIP6963ManagerContextProvider } from './providers/EIP6963ManagerProvider.tsx'
+import { EIP6963ContextProvider } from './providers/EIP6963Provider.tsx'
 
 const router = createHashRouter([
   {
@@ -34,9 +36,13 @@ const router = createHashRouter([
 ])
 
 export const App: FC = () => (
-  <EIP1193ContextProvider>
-    <Web3ContextProvider>
-      <RouterProvider router={router} />
-    </Web3ContextProvider>
-  </EIP1193ContextProvider>
+  <EIP6963ManagerContextProvider>
+    <EIP1193ContextProvider>
+      <EIP6963ContextProvider>
+        <Web3ContextProvider>
+          <RouterProvider router={router} />
+        </Web3ContextProvider>
+      </EIP6963ContextProvider>
+    </EIP1193ContextProvider>
+  </EIP6963ManagerContextProvider>
 )

--- a/src/components/WalletModal/index.module.css
+++ b/src/components/WalletModal/index.module.css
@@ -1,0 +1,64 @@
+.walletModalContent {
+  display: flex;
+  flex-direction: column;
+  padding-bottom: 2rem;
+
+  h4 {
+    color: var(--gray-extra-dark);
+    margin-bottom: 2rem;
+    text-align: center;
+  }
+}
+
+.walletModalLogo {
+  align-self: center;
+  margin-bottom: 3.125rem;
+}
+
+.walletModalProviderList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+
+  .providerOption {
+    background-color: var(--gray-medium-light);
+    border-radius: 46px;
+  }
+}
+
+.providerOptionBtn {
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 2rem;
+  gap: 0.75rem;
+  background: none;
+  border: none;
+  font: inherit;
+  outline: inherit;
+  color: var(--gray-extra-dark);
+  cursor: pointer;
+  width: 100%;
+  border-radius: 46px;
+
+  &:hover,
+  &:focus {
+    background-color: var(--gray-extra-dark);
+    color: var(--white);
+  }
+}
+
+.providerOptionLogo {
+  object-fit: cover;
+  width: 45px;
+  height: 45px;
+}
+
+@media screen and (max-width: 1000px) {
+  .walletModal {
+    max-width: unset;
+  }
+
+  .walletModalLogo {
+    margin-bottom: 2rem;
+  }
+}

--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -1,0 +1,74 @@
+import { FC, useState } from 'react'
+import { Modal, ModalProps } from '../Modal'
+import { LogoIconRound } from '../icons/LogoIconRound.tsx'
+import classes from './index.module.css'
+import { useEIP6963ProviderInfoList } from '../../hooks/useEIP6963ProviderInfoList.ts'
+import { EIP6963ProviderInfo } from '../../utils/types.ts'
+import { useEIP6963 } from '../../hooks/useEIP6963.ts'
+
+interface WalletModalProps extends Pick<ModalProps, 'isOpen' | 'closeModal'> {
+  next: () => void
+}
+
+interface ProviderOptionProps extends Pick<EIP6963ProviderInfo, 'rdns' | 'name' | 'icon'> {
+  isLoading: boolean
+  onSelectProvider: (rdns: string) => void
+}
+
+const ProviderOption: FC<ProviderOptionProps> = ({ rdns, name, icon, onSelectProvider, isLoading }) => {
+  if (!rdns) {
+    return null
+  }
+
+  return (
+    <div className={classes.providerOption}>
+      <button
+        className={classes.providerOptionBtn}
+        onClick={() => onSelectProvider(rdns)}
+        disabled={isLoading}
+      >
+        <img className={classes.providerOptionLogo} src={icon} alt={name} />
+        {name}
+      </button>
+    </div>
+  )
+}
+
+export const WalletModal: FC<WalletModalProps> = ({ isOpen, closeModal, next }) => {
+  const { setCurrentProviderByRdns } = useEIP6963()
+  const providerInfoList = useEIP6963ProviderInfoList()
+
+  const [isLoading, setIsLoading] = useState(false)
+
+  const onSelectProvider = (rdns: string) => {
+    setIsLoading(true)
+    setCurrentProviderByRdns(rdns)
+    next()
+    setIsLoading(false)
+  }
+
+  const providerInfoOptionsList = providerInfoList.map(({ uuid, rdns, name, icon }) => (
+    <ProviderOption
+      key={uuid}
+      rdns={rdns}
+      name={name}
+      icon={icon}
+      isLoading={isLoading}
+      onSelectProvider={onSelectProvider}
+    />
+  ))
+
+  return (
+    <Modal isOpen={isOpen} closeModal={closeModal} disableBackdropClick>
+      <div className={classes.walletModalContent}>
+        <div className={classes.walletModalLogo}>
+          <LogoIconRound />
+        </div>
+
+        <h4>Connect a wallet</h4>
+
+        <div className={classes.walletModalProviderList}>{providerInfoOptionsList}</div>
+      </div>
+    </Modal>
+  )
+}

--- a/src/hooks/useEIP1193.ts
+++ b/src/hooks/useEIP1193.ts
@@ -3,7 +3,7 @@ import { EIP1193Context } from '../providers/EIP1193Context'
 
 export const useEIP1193 = () => {
   const value = useContext(EIP1193Context)
-  if (value === undefined) {
+  if (Object.keys(value).length === 0) {
     throw new Error('[useEIP1193] Component not wrapped within a Provider')
   }
 

--- a/src/hooks/useEIP1193.ts
+++ b/src/hooks/useEIP1193.ts
@@ -1,0 +1,11 @@
+import { useContext } from 'react'
+import { EIP1193Context } from '../providers/EIP1193Context'
+
+export const useEIP1193 = () => {
+  const value = useContext(EIP1193Context)
+  if (value === undefined) {
+    throw new Error('[useEIP1193] Component not wrapped within a Provider')
+  }
+
+  return value
+}

--- a/src/hooks/useEIP6963.ts
+++ b/src/hooks/useEIP6963.ts
@@ -3,7 +3,7 @@ import { EIP6963Context } from '../providers/EIP6963Context.ts'
 
 export const useEIP6963 = () => {
   const value = useContext(EIP6963Context)
-  if (value === undefined) {
+  if (Object.keys(value).length === 0) {
     throw new Error('[useEIP6963] Component not wrapped within a Provider')
   }
 

--- a/src/hooks/useEIP6963.ts
+++ b/src/hooks/useEIP6963.ts
@@ -1,0 +1,11 @@
+import { useContext } from 'react'
+import { EIP6963Context } from '../providers/EIP6963Context.ts'
+
+export const useEIP6963 = () => {
+  const value = useContext(EIP6963Context)
+  if (value === undefined) {
+    throw new Error('[useEIP6963] Component not wrapped within a Provider')
+  }
+
+  return value
+}

--- a/src/hooks/useEIP6963Manager.ts
+++ b/src/hooks/useEIP6963Manager.ts
@@ -1,0 +1,11 @@
+import { useContext } from 'react'
+import { EIP6963ManagerContext } from '../providers/EIP6963ManagerContext.ts'
+
+export const useEIP6963Manager = () => {
+  const value = useContext(EIP6963ManagerContext)
+  if (value === undefined) {
+    throw new Error('[useEIP6963Manager] Component not wrapped within a Provider')
+  }
+
+  return value
+}

--- a/src/hooks/useEIP6963Manager.ts
+++ b/src/hooks/useEIP6963Manager.ts
@@ -3,7 +3,7 @@ import { EIP6963ManagerContext } from '../providers/EIP6963ManagerContext.ts'
 
 export const useEIP6963Manager = () => {
   const value = useContext(EIP6963ManagerContext)
-  if (value === undefined) {
+  if (Object.keys(value).length === 0) {
     throw new Error('[useEIP6963Manager] Component not wrapped within a Provider')
   }
 

--- a/src/hooks/useEIP6963ProviderInfoList.ts
+++ b/src/hooks/useEIP6963ProviderInfoList.ts
@@ -1,0 +1,10 @@
+import { useEIP6963Manager } from './useEIP6963Manager.ts'
+import { EIP6963ProviderInfo } from '../utils/types.ts'
+
+export const useEIP6963ProviderInfoList = (): EIP6963ProviderInfo[] => {
+  const {
+    state: { providerList },
+  } = useEIP6963Manager()
+
+  return providerList.map(({ info }) => info)
+}

--- a/src/hooks/useWeb3.ts
+++ b/src/hooks/useWeb3.ts
@@ -3,7 +3,7 @@ import { Web3Context } from '../providers/Web3Context'
 
 export const useWeb3 = () => {
   const value = useContext(Web3Context)
-  if (value === undefined) {
+  if (Object.keys(value).length === 0) {
     throw new Error('[useWeb3] Component not wrapped within a Provider')
   }
 

--- a/src/hooks/useWrapForm.ts
+++ b/src/hooks/useWrapForm.ts
@@ -3,7 +3,7 @@ import { WrapFormContext } from '../providers/WrapFormContext'
 
 export const useWrapForm = () => {
   const value = useContext(WrapFormContext)
-  if (value === undefined) {
+  if (Object.keys(value).length === 0) {
     throw new Error('[useWrapForm] Component not wrapped within a Provider')
   }
 

--- a/src/pages/ConnectWallet/index.tsx
+++ b/src/pages/ConnectWallet/index.tsx
@@ -7,16 +7,16 @@ import { METAMASK_HOME_PAGE } from '../../constants/config'
 import { useWeb3 } from '../../hooks/useWeb3'
 
 export const ConnectWallet: FC = () => {
-  const { connectWallet, switchNetwork, isMetaMaskInstalled } = useWeb3()
+  const { connectWallet, switchNetwork, isProviderAvailable } = useWeb3()
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState('')
-  const [hasMetaMaskWallet, setHasMetaMaskWallet] = useState(true)
+  const [providerAvailable, setProviderAvailable] = useState(true)
   const [isUnknownNetwork, setIsUnknownNetwork] = useState(false)
 
   useEffect(() => {
     const init = async () => {
       setIsLoading(true)
-      setHasMetaMaskWallet(await isMetaMaskInstalled())
+      setProviderAvailable(await isProviderAvailable())
       setIsLoading(false)
     }
 
@@ -53,7 +53,7 @@ export const ConnectWallet: FC = () => {
 
   return (
     <>
-      {!hasMetaMaskWallet && (
+      {!providerAvailable && (
         <div>
           <p className={classes.subHeader}>
             Quickly wrap your ROSE into wROSE and vice versa with the (un)wrap ROSE tool.
@@ -68,7 +68,7 @@ export const ConnectWallet: FC = () => {
           </a>
           <Button
             variant="secondary"
-            onClick={() => setHasMetaMaskWallet(true)}
+            onClick={() => setProviderAvailable(true)}
             disabled={isLoading}
             fullWidth
           >
@@ -76,7 +76,7 @@ export const ConnectWallet: FC = () => {
           </Button>
         </div>
       )}
-      {hasMetaMaskWallet && (
+      {providerAvailable && (
         <>
           {!isUnknownNetwork && (
             <div>

--- a/src/providers/EIP1193Context.ts
+++ b/src/providers/EIP1193Context.ts
@@ -1,0 +1,10 @@
+import { createContext } from 'react'
+
+export interface EIP1193ProviderContext {
+  isEIP1193ProviderAvailable: () => Promise<boolean>
+  connectWallet: () => Promise<string>
+  switchNetwork: (chainId: number) => void
+  addTokenToWallet: (wRoseContractAddress: string) => Promise<void>
+}
+
+export const EIP1193Context = createContext<EIP1193ProviderContext>({} as EIP1193ProviderContext)

--- a/src/providers/EIP1193Context.ts
+++ b/src/providers/EIP1193Context.ts
@@ -1,10 +1,11 @@
 import { createContext } from 'react'
+import { EIP1193Provider } from '../utils/types.ts'
 
 export interface EIP1193ProviderContext {
   isEIP1193ProviderAvailable: () => Promise<boolean>
-  connectWallet: () => Promise<string>
-  switchNetwork: (chainId: number) => void
-  addTokenToWallet: (wRoseContractAddress: string) => Promise<void>
+  connectWallet: (provider?: EIP1193Provider) => Promise<string>
+  switchNetwork: (chainId: number, provider?: EIP1193Provider) => void
+  addTokenToWallet: (wRoseContractAddress: string, provider?: EIP1193Provider) => Promise<void>
 }
 
 export const EIP1193Context = createContext<EIP1193ProviderContext>({} as EIP1193ProviderContext)

--- a/src/providers/EIP1193Provider.tsx
+++ b/src/providers/EIP1193Provider.tsx
@@ -1,0 +1,115 @@
+import { FC, PropsWithChildren } from 'react'
+import { ethers, utils } from 'ethers'
+import * as sapphire from '@oasisprotocol/sapphire-paratime'
+import { MetaMaskError } from '../utils/errors'
+import detectEthereumProvider from '@metamask/detect-provider'
+import { EIP1193Context, EIP1193ProviderContext } from './EIP1193Context.ts'
+
+declare global {
+  interface Window {
+    ethereum?: ethers.providers.ExternalProvider & ethers.providers.Web3Provider
+  }
+}
+
+export const EIP1193ContextProvider: FC<PropsWithChildren> = ({ children }) => {
+  const isEIP1193ProviderAvailable = async () => {
+    const provider = await detectEthereumProvider({
+      // Explicitly set, provider doesn't have to be MetaMask
+      mustBeMetaMask: false,
+    })
+
+    return !!window.ethereum && provider === window.ethereum
+  }
+
+  const connectWallet = async (): Promise<string> => {
+    const accounts: string[] = await (window.ethereum?.request?.({ method: 'eth_requestAccounts' }) ||
+      Promise.resolve([]))
+
+    if (!accounts || accounts?.length <= 0) {
+      throw new Error('[EIP1193Context] Request account failed!')
+    }
+
+    return accounts[0]
+  }
+
+  const _addNetwork = (chainId: number) => {
+    if (chainId === 0x5afe) {
+      // Default to Sapphire Mainnet
+      return window.ethereum?.request?.({
+        method: 'wallet_addEthereumChain',
+        params: [
+          {
+            chainId: '0x5afe',
+            chainName: 'Oasis Sapphire',
+            nativeCurrency: {
+              name: 'ROSE',
+              symbol: 'ROSE',
+              decimals: 18,
+            },
+            rpcUrls: ['https://sapphire.oasis.io/', 'wss://sapphire.oasis.io/ws'],
+            blockExplorerUrls: ['https://explorer.oasis.io/mainnet/sapphire'],
+          },
+        ],
+      })
+    }
+
+    throw new Error('Unable to automatically add the network, please do it manually!')
+  }
+
+  const switchNetwork = async (chainId = 0x5afe) => {
+    const ethProvider = new ethers.providers.Web3Provider(window.ethereum!)
+    const sapphireEthProvider = sapphire.wrap(ethProvider) as ethers.providers.Web3Provider &
+      sapphire.SapphireAnnex
+
+    const network = await sapphireEthProvider.getNetwork()
+
+    if (network.chainId === chainId) return
+    try {
+      await window.ethereum!.request?.({
+        method: 'wallet_switchEthereumChain',
+        params: [{ chainId: utils.hexlify(chainId) }],
+      })
+    } catch (e) {
+      const metaMaskError = e as MetaMaskError
+      // Metamask desktop - Throws e.code 4902 when chain is not available
+      // Metamask mobile - Throws generic -32603 (https://github.com/MetaMask/metamask-mobile/issues/3312)
+
+      if (metaMaskError?.code !== 4902 && metaMaskError?.code !== -32603) {
+        throw metaMaskError
+      } else {
+        _addNetwork(chainId)
+      }
+    }
+  }
+
+  const addTokenToWallet = async (wRoseContractAddress: string) => {
+    const symbol = 'WROSE'
+
+    try {
+      await window.ethereum?.request?.({
+        method: 'wallet_watchAsset',
+        params: {
+          type: 'ERC20',
+          options: {
+            address: wRoseContractAddress,
+            symbol,
+            decimals: 18,
+          },
+          // Fails if Array
+        } as unknown as never,
+      })
+    } catch (ex) {
+      // Silently fail
+      console.error(ex)
+    }
+  }
+
+  const providerState: EIP1193ProviderContext = {
+    isEIP1193ProviderAvailable,
+    connectWallet,
+    switchNetwork,
+    addTokenToWallet,
+  }
+
+  return <EIP1193Context.Provider value={providerState}>{children}</EIP1193Context.Provider>
+}

--- a/src/providers/EIP6963Context.ts
+++ b/src/providers/EIP6963Context.ts
@@ -1,5 +1,6 @@
 import { createContext } from 'react'
 import { EIP6963ClassProvider } from '../utils/EIP6963Provider.class.ts'
+import { EIP1193Provider } from '../utils/types.ts'
 
 export interface EIP6963ProviderState {
   provider: EIP6963ClassProvider
@@ -12,6 +13,8 @@ export interface EIP6963ProviderContext {
   connectWallet: () => Promise<string>
   switchNetwork: (chainId: number) => void
   addTokenToWallet: (wRoseContractAddress: string) => Promise<void>
+  setCurrentProviderByRdns: (rdns: string) => void
+  getCurrentProvider: () => EIP1193Provider | undefined
 }
 
 export const EIP6963Context = createContext<EIP6963ProviderContext>({} as EIP6963ProviderContext)

--- a/src/providers/EIP6963Context.ts
+++ b/src/providers/EIP6963Context.ts
@@ -1,0 +1,17 @@
+import { createContext } from 'react'
+import { EIP6963ClassProvider } from '../utils/EIP6963Provider.class.ts'
+
+export interface EIP6963ProviderState {
+  provider: EIP6963ClassProvider
+  isEIP6963ProviderAvailable: boolean
+}
+
+export interface EIP6963ProviderContext {
+  readonly state: EIP6963ProviderState
+  isEIP6963ProviderAvailableSync: () => boolean
+  connectWallet: () => Promise<string>
+  switchNetwork: (chainId: number) => void
+  addTokenToWallet: (wRoseContractAddress: string) => Promise<void>
+}
+
+export const EIP6963Context = createContext<EIP6963ProviderContext>({} as EIP6963ProviderContext)

--- a/src/providers/EIP6963ManagerContext.ts
+++ b/src/providers/EIP6963ManagerContext.ts
@@ -1,0 +1,18 @@
+import { createContext } from 'react'
+import { EIP6963ProviderDetail } from '../utils/types.ts'
+
+export interface EIP6963ManagerProviderState {
+  providerList: EIP6963ProviderDetail[]
+}
+
+export interface EIP6963ManagerProviderContext {
+  readonly state: EIP6963ManagerProviderState
+}
+
+type MutableInjectedProviderMap = Map<string, EIP6963ProviderDetail>
+
+export const EIP6963_MANAGER_INJECTED_PROVIDERS_MAP: MutableInjectedProviderMap = new Map()
+
+export const EIP6963ManagerContext = createContext<EIP6963ManagerProviderContext>(
+  {} as EIP6963ManagerProviderContext,
+)

--- a/src/providers/EIP6963ManagerProvider.tsx
+++ b/src/providers/EIP6963ManagerProvider.tsx
@@ -1,0 +1,69 @@
+import { FC, PropsWithChildren, useEffect, useState } from 'react'
+import {
+  EIP6963_MANAGER_INJECTED_PROVIDERS_MAP,
+  EIP6963ManagerContext,
+  EIP6963ManagerProviderContext,
+  EIP6963ManagerProviderState,
+} from './EIP6963ManagerContext.ts'
+import { EIP6963AnnounceProviderEvent, EIP6963Event } from '../utils/types.ts'
+import { EIPUtils } from '../utils/eip.utils.ts'
+
+interface CustomEventMap {
+  [EIP6963Event.ANNOUNCE_PROVIDER]: CustomEvent<EIP6963AnnounceProviderEvent>
+}
+
+declare global {
+  interface Document {
+    addEventListener<K extends keyof CustomEventMap>(
+      type: K,
+      listener: (this: Document, ev: CustomEventMap[K]) => void,
+    ): void
+
+    dispatchEvent<K extends keyof CustomEventMap>(ev: CustomEventMap[K]): void
+  }
+}
+
+const eip6963ManagerProviderInitialState: EIP6963ManagerProviderState = {
+  providerList: [],
+}
+
+export const EIP6963ManagerContextProvider: FC<PropsWithChildren> = ({ children }) => {
+  const [state, setState] = useState<EIP6963ManagerProviderState>({
+    ...eip6963ManagerProviderInitialState,
+  })
+
+  const _onAnnounceProvider: EIP6963AnnounceProviderEvent = event => {
+    if (!EIPUtils.isEIP6963Provider(event.detail)) {
+      return
+    }
+
+    const { detail } = event
+
+    // Ignore duplicated providers with same rdns
+    const providerDetails = EIP6963_MANAGER_INJECTED_PROVIDERS_MAP.get(detail.info.rdns!)
+    if (providerDetails) {
+      if (providerDetails.provider !== detail.provider) {
+        console.warn(`Duplicate provider detected for wallet with rdns: ${detail.info.rdns}!`)
+      }
+      return
+    }
+
+    EIP6963_MANAGER_INJECTED_PROVIDERS_MAP.set(detail.info.rdns!, detail)
+
+    setState(prevState => ({
+      ...prevState,
+      providerList: [...prevState.providerList, detail],
+    }))
+  }
+
+  useEffect(() => {
+    window.addEventListener(EIP6963Event.ANNOUNCE_PROVIDER, _onAnnounceProvider as EventListener)
+    window.dispatchEvent(new Event(EIP6963Event.REQUEST_PROVIDER))
+  }, [])
+
+  const providerState: EIP6963ManagerProviderContext = {
+    state,
+  }
+
+  return <EIP6963ManagerContext.Provider value={providerState}>{children}</EIP6963ManagerContext.Provider>
+}

--- a/src/providers/EIP6963Provider.tsx
+++ b/src/providers/EIP6963Provider.tsx
@@ -24,10 +24,18 @@ export const EIP6963ContextProvider: FC<PropsWithChildren> = ({ children }) => {
   })
 
   useEffect(() => {
-    setState(prevState => ({
-      ...prevState,
-      isEIP6963ProviderAvailable: !!providerList.length,
-    }))
+    const { isEIP6963ProviderAvailable } = state
+
+    const isEIP6963ProviderAvailableNext = !!providerList.length
+
+    if (isEIP6963ProviderAvailable !== isEIP6963ProviderAvailableNext) {
+      setState(prevState => ({
+        ...prevState,
+        isEIP6963ProviderAvailable: isEIP6963ProviderAvailableNext,
+      }))
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [providerList])
 
   const isEIP6963ProviderAvailableSync = () => {
@@ -52,12 +60,26 @@ export const EIP6963ContextProvider: FC<PropsWithChildren> = ({ children }) => {
     return addTokenToWalletEIP1193(wRoseContractAddress, provider)
   }
 
+  const setCurrentProviderByRdns = (rdns: string) => {
+    const { provider } = state
+
+    provider.setCurrentProvider(rdns)
+  }
+
+  const getCurrentProvider = () => {
+    const { provider } = state
+
+    return provider.currentProviderDetail?.provider
+  }
+
   const providerState: EIP6963ProviderContext = {
     state,
     isEIP6963ProviderAvailableSync,
     connectWallet,
     switchNetwork,
     addTokenToWallet,
+    setCurrentProviderByRdns,
+    getCurrentProvider,
   }
 
   return <EIP6963Context.Provider value={providerState}>{children}</EIP6963Context.Provider>

--- a/src/providers/EIP6963Provider.tsx
+++ b/src/providers/EIP6963Provider.tsx
@@ -1,0 +1,64 @@
+import { FC, PropsWithChildren, useEffect, useState } from 'react'
+import { EIP6963Context, EIP6963ProviderContext, EIP6963ProviderState } from './EIP6963Context.ts'
+import { EIP6963ClassProvider } from '../utils/EIP6963Provider.class.ts'
+import { useEIP6963Manager } from '../hooks/useEIP6963Manager.ts'
+import { useEIP1193 } from '../hooks/useEIP1193.ts'
+
+const eip6963ProviderInitialState: EIP6963ProviderState = {
+  provider: new EIP6963ClassProvider(),
+  isEIP6963ProviderAvailable: false,
+}
+
+export const EIP6963ContextProvider: FC<PropsWithChildren> = ({ children }) => {
+  const {
+    state: { providerList },
+  } = useEIP6963Manager()
+  const {
+    connectWallet: connectWalletEIP1193,
+    switchNetwork: switchNetworkEIP1193,
+    addTokenToWallet: addTokenToWalletEIP1193,
+  } = useEIP1193()
+
+  const [state, setState] = useState<EIP6963ProviderState>({
+    ...eip6963ProviderInitialState,
+  })
+
+  useEffect(() => {
+    setState(prevState => ({
+      ...prevState,
+      isEIP6963ProviderAvailable: !!providerList.length,
+    }))
+  }, [providerList])
+
+  const isEIP6963ProviderAvailableSync = () => {
+    return providerList.length > 0
+  }
+
+  const connectWallet = async (): Promise<string> => {
+    const { provider } = state
+
+    return await connectWalletEIP1193(provider)
+  }
+
+  const switchNetwork = async (chainId = 0x5afe) => {
+    const { provider } = state
+
+    return switchNetworkEIP1193(chainId, provider)
+  }
+
+  const addTokenToWallet = async (wRoseContractAddress: string) => {
+    const { provider } = state
+
+    return addTokenToWalletEIP1193(wRoseContractAddress, provider)
+  }
+
+  const providerState: EIP6963ProviderContext = {
+    state,
+    isEIP6963ProviderAvailableSync,
+    connectWallet,
+    switchNetwork,
+    addTokenToWallet,
+  }
+
+  return <EIP6963Context.Provider value={providerState}>{children}</EIP6963Context.Provider>
+}

--- a/src/providers/Web3Context.ts
+++ b/src/providers/Web3Context.ts
@@ -24,7 +24,7 @@ export interface Web3ProviderContext {
   readonly state: Web3ProviderState
   wrap: (amount: string, gasPrice: BigNumber) => Promise<TransactionResponse>
   unwrap: (amount: string, gasPrice: BigNumber) => Promise<TransactionResponse>
-  connectWallet: () => Promise<void>
+  connectWallet: (providerType?: ProviderType) => Promise<void>
   switchNetwork: (chainId?: number) => Promise<void>
   getBalance: () => Promise<BigNumber>
   getBalanceOfWROSE: () => Promise<BigNumber>

--- a/src/providers/Web3Context.ts
+++ b/src/providers/Web3Context.ts
@@ -3,6 +3,11 @@ import { BigNumber, ethers } from 'ethers'
 import * as sapphire from '@oasisprotocol/sapphire-paratime'
 import { TransactionResponse } from '@ethersproject/abstract-provider'
 
+export enum ProviderType {
+  EIP1193,
+  EIP6963,
+}
+
 export interface Web3ProviderState {
   isConnected: boolean
   ethProvider: ethers.providers.Web3Provider | null
@@ -12,20 +17,21 @@ export interface Web3ProviderState {
   account: string | null
   explorerBaseUrl: string | null
   networkName: string | null
+  providerType: ProviderType
 }
 
 export interface Web3ProviderContext {
   readonly state: Web3ProviderState
   wrap: (amount: string, gasPrice: BigNumber) => Promise<TransactionResponse>
   unwrap: (amount: string, gasPrice: BigNumber) => Promise<TransactionResponse>
-  isMetaMaskInstalled: () => Promise<boolean>
   connectWallet: () => Promise<void>
-  switchNetwork: () => Promise<void>
+  switchNetwork: (chainId?: number) => Promise<void>
   getBalance: () => Promise<BigNumber>
   getBalanceOfWROSE: () => Promise<BigNumber>
   getTransaction: (txHash: string) => Promise<TransactionResponse>
   addTokenToWallet: () => Promise<void>
   getGasPrice: () => Promise<BigNumber>
+  isProviderAvailable: () => Promise<boolean>
 }
 
 export const Web3Context = createContext<Web3ProviderContext>({} as Web3ProviderContext)

--- a/src/providers/Web3Provider.tsx
+++ b/src/providers/Web3Provider.tsx
@@ -1,19 +1,13 @@
 import { FC, PropsWithChildren, useCallback, useState } from 'react'
-import { BigNumber, ethers, utils } from 'ethers'
+import { BigNumber, ethers } from 'ethers'
 import * as sapphire from '@oasisprotocol/sapphire-paratime'
 import { MAX_GAS_LIMIT, NETWORKS } from '../constants/config'
 // https://repo.sourcify.dev/contracts/full_match/23295/0xB759a0fbc1dA517aF257D5Cf039aB4D86dFB3b94/
 // https://repo.sourcify.dev/contracts/full_match/23294/0x8Bc2B030b299964eEfb5e1e0b36991352E56D2D3/
 import WrappedRoseMetadata from '../contracts/WrappedROSE.json'
-import { MetaMaskError, UnknownNetworkError } from '../utils/errors'
-import detectEthereumProvider from '@metamask/detect-provider'
-import { Web3ProviderContext, Web3ProviderState, Web3Context } from './Web3Context'
-
-declare global {
-  interface Window {
-    ethereum?: ethers.providers.ExternalProvider & ethers.providers.Web3Provider
-  }
-}
+import { UnknownNetworkError } from '../utils/errors'
+import { ProviderType, Web3Context, Web3ProviderContext, Web3ProviderState } from './Web3Context'
+import { useEIP1193 } from '../hooks/useEIP1193.ts'
 
 const web3ProviderInitialState: Web3ProviderState = {
   isConnected: false,
@@ -24,9 +18,17 @@ const web3ProviderInitialState: Web3ProviderState = {
   account: null,
   explorerBaseUrl: null,
   networkName: null,
+  providerType: ProviderType.EIP1193,
 }
 
 export const Web3ContextProvider: FC<PropsWithChildren> = ({ children }) => {
+  const {
+    isEIP1193ProviderAvailable,
+    connectWallet: connectWalletEIP1193,
+    switchNetwork: switchNetworkEIP1193,
+    addTokenToWallet: addTokenToWalletEIP1193,
+  } = useEIP1193()
+
   const [state, setState] = useState<Web3ProviderState>({
     ...web3ProviderInitialState,
   })
@@ -88,32 +90,30 @@ export const Web3ContextProvider: FC<PropsWithChildren> = ({ children }) => {
   const _connect = useCallback(() => _connectionChanged(true), [])
   const _disconnect = useCallback(() => _connectionChanged(false), [])
 
-  const _addEventListeners = (ethProvider = window.ethereum!) => {
-    ethProvider.on('accountsChanged', _accountsChanged)
-    ethProvider.on('chainChanged', _chainChanged)
-    ethProvider.on('connect', _connect)
-    ethProvider.on('disconnect', _disconnect)
-  }
+  const _addEventListenersOnce = (() => {
+    let eventListenersInitialized = false
+    return (ethProvider: typeof window.ethereum) => {
+      if (eventListenersInitialized) {
+        return
+      }
 
-  const _removeEventListeners = (ethProvider = window.ethereum!) => {
-    ethProvider.off('accountsChanged', _accountsChanged)
-    ethProvider.off('chainChanged', _chainChanged)
-    ethProvider.off('connect', _connect)
-    ethProvider.off('disconnect', _disconnect)
-  }
+      ethProvider?.on?.('accountsChanged', _accountsChanged)
+      ethProvider?.on?.('chainChanged', _chainChanged)
+      ethProvider?.on?.('connect', _connect)
+      ethProvider?.on?.('disconnect', _disconnect)
 
-  const _init = async (account: string) => {
-    _removeEventListeners()
+      eventListenersInitialized = true
+    }
+  })()
 
+  const _init = async (account: string, provider: typeof window.ethereum) => {
     try {
-      const ethProvider = new ethers.providers.Web3Provider(window.ethereum!)
+      const ethProvider = new ethers.providers.Web3Provider(provider!)
       const sapphireEthProvider = sapphire.wrap(ethProvider) as ethers.providers.Web3Provider &
         sapphire.SapphireAnnex
 
       const network = await sapphireEthProvider.getNetwork()
       _setNetworkSpecificVars(network.chainId, sapphireEthProvider)
-
-      _addEventListeners()
 
       setState(prevState => ({
         ...prevState,
@@ -156,70 +156,52 @@ export const Web3ContextProvider: FC<PropsWithChildren> = ({ children }) => {
     return await wRoseContract.balanceOf(account)
   }
 
-  const isMetaMaskInstalled = async () => {
-    const provider = await detectEthereumProvider()
+  const isProviderAvailable = async () => {
+    const { providerType } = state
 
-    return !!window.ethereum && provider === window.ethereum
+    switch (providerType) {
+      case ProviderType.EIP1193:
+        return isEIP1193ProviderAvailable()
+      default:
+        return false
+    }
+  }
+
+  const _getConnectedAccount = () => {
+    const { providerType } = state
+
+    switch (providerType) {
+      case ProviderType.EIP1193:
+        return connectWalletEIP1193()
+      default:
+        return
+    }
   }
 
   const connectWallet = async () => {
-    const accounts: string[] = await (window.ethereum?.request?.({ method: 'eth_requestAccounts' }) ||
-      Promise.resolve([]))
+    const { providerType } = state
+    const account = await _getConnectedAccount()
 
-    if (!accounts || accounts?.length <= 0) {
+    if (!account) {
       throw new Error('[Web3Context] Request account failed!')
     }
 
-    await _init(accounts[0])
-  }
-
-  const _addNetwork = async (chainId: number) => {
-    if (chainId === 0x5afe) {
-      // Default to Sapphire Mainnet
-      return await window.ethereum?.request?.({
-        method: 'wallet_addEthereumChain',
-        params: [
-          {
-            chainId: '0x5afe',
-            chainName: 'Oasis Sapphire',
-            nativeCurrency: {
-              name: 'ROSE',
-              symbol: 'ROSE',
-              decimals: 18,
-            },
-            rpcUrls: ['https://sapphire.oasis.io/', 'wss://sapphire.oasis.io/ws'],
-            blockExplorerUrls: ['https://explorer.oasis.io/mainnet/sapphire'],
-          },
-        ],
-      })
-    }
-
-    throw new Error('Unable to automatically add the network, please do it manually!')
-  }
-
-  const switchNetwork = async (toNetworkChainId = 0x5afe) => {
-    const ethProvider = new ethers.providers.Web3Provider(window.ethereum!)
-    const sapphireEthProvider = sapphire.wrap(ethProvider) as ethers.providers.Web3Provider &
-      sapphire.SapphireAnnex
-
-    const network = await sapphireEthProvider.getNetwork()
-
-    if (network.chainId === toNetworkChainId) return
-    try {
-      await window.ethereum!.request?.({
-        method: 'wallet_switchEthereumChain',
-        params: [{ chainId: utils.hexlify(toNetworkChainId) }],
-      })
-    } catch (e) {
-      const metaMaskError = e as MetaMaskError
-      // Metamask desktop - Throws e.code 4902 when chain is not available
-      // Metamask mobile - Throws generic -32603 (https://github.com/MetaMask/metamask-mobile/issues/3312)
-
-      if (metaMaskError?.code !== 4902 && metaMaskError?.code !== -32603) {
-        throw metaMaskError
-      } else {
-        _addNetwork(toNetworkChainId)
+    switch (providerType) {
+      case ProviderType.EIP1193: {
+        await _init(account, window.ethereum)
+        _addEventListenersOnce(window.ethereum)
       }
+    }
+  }
+
+  const switchNetwork = async (chainId = 0x5afe) => {
+    const { providerType } = state
+
+    switch (providerType) {
+      case ProviderType.EIP1193:
+        return switchNetworkEIP1193(chainId)
+      default:
+        return
     }
   }
 
@@ -280,31 +262,21 @@ export const Web3ContextProvider: FC<PropsWithChildren> = ({ children }) => {
   }
 
   const addTokenToWallet = async () => {
-    const { wRoseContractAddress: address } = state
-    const symbol = 'WROSE'
+    const { wRoseContractAddress, providerType } = state
 
-    try {
-      await window.ethereum?.request?.({
-        method: 'wallet_watchAsset',
-        params: {
-          type: 'ERC20',
-          options: {
-            address,
-            symbol,
-            decimals: 18,
-          },
-          // Fails if Array
-        } as unknown as never,
-      })
-    } catch (ex) {
-      // Silently fail
-      console.error(ex)
+    if (!wRoseContractAddress) {
+      return
+    }
+
+    switch (providerType) {
+      case ProviderType.EIP1193:
+        return addTokenToWalletEIP1193(wRoseContractAddress)
     }
   }
 
   const providerState: Web3ProviderContext = {
     state,
-    isMetaMaskInstalled,
+    isProviderAvailable,
     connectWallet,
     switchNetwork,
     wrap,

--- a/src/utils/EIP6963Provider.class.ts
+++ b/src/utils/EIP6963Provider.class.ts
@@ -1,0 +1,64 @@
+import { EIP1193Provider, EIP6963ProviderDetail } from './types.ts'
+import { EIP6963_MANAGER_INJECTED_PROVIDERS_MAP } from '../providers/EIP6963ManagerContext.ts'
+
+interface Listener<T = unknown> {
+  (...args: T[]): void
+}
+
+export class EIP6963ClassProvider implements EIP1193Provider {
+  currentProviderDetail?: EIP6963ProviderDetail
+
+  // Stores stable references to prevent memory leaks
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private readonly proxyListeners: { [eventName: string | symbol]: Listener<any>[] } = {}
+
+  request = async <T = object | unknown[], R = unknown>(args: { method: string; params?: T }): Promise<R> =>
+    this.currentProviderDetail && this.currentProviderDetail.provider
+      ? this.currentProviderDetail.provider.request<T, R>(args)
+      : Promise.reject('Provider is undefined')
+
+  on = <T = unknown>(eventName: string, listener: Listener<T>): this => {
+    if (!this.proxyListeners[eventName]) {
+      this.proxyListeners[eventName] = []
+    }
+    this.proxyListeners[eventName].push(listener)
+    this.currentProviderDetail?.provider.on(eventName, listener)
+
+    return this
+  }
+
+  removeListener = <T = unknown>(eventName: string | symbol, listener: Listener<T>): this => {
+    this.currentProviderDetail?.provider.removeListener(eventName, listener)
+
+    if (this.proxyListeners[eventName]) {
+      const index = this.proxyListeners[eventName]?.indexOf(listener)
+      if (index !== -1) {
+        // proxyListeners must be referentially stable
+        this.proxyListeners[eventName]?.splice(index, 1)
+      }
+    }
+
+    return this
+  }
+
+  private transferListeners(
+    eventName: string,
+    newProvider?: EIP6963ProviderDetail,
+    oldProvider?: EIP6963ProviderDetail,
+  ): void {
+    if (!eventName) return
+    for (const proxyListener of this.proxyListeners[eventName]) {
+      oldProvider?.provider.removeListener(eventName, proxyListener)
+      newProvider?.provider.on(eventName, proxyListener)
+    }
+  }
+
+  setCurrentProvider(rdns: string) {
+    const oldProvider = this.currentProviderDetail
+    const newProvider = (this.currentProviderDetail = EIP6963_MANAGER_INJECTED_PROVIDERS_MAP.get(rdns))
+
+    for (const eventName in this.proxyListeners) {
+      this.transferListeners(eventName, newProvider, oldProvider)
+    }
+  }
+}

--- a/src/utils/eip.utils.ts
+++ b/src/utils/eip.utils.ts
@@ -1,0 +1,17 @@
+import { EIP1193Provider, EIP6963ProviderDetail } from './types.ts'
+
+export abstract class EIPUtils {
+  static isEIP1193Provider(value: Partial<EIP1193Provider>): value is EIP1193Provider {
+    return !!(value.request && value.on && value.removeListener)
+  }
+
+  static isEIP6963Provider = (value: Partial<EIP6963ProviderDetail>): value is EIP6963ProviderDetail => {
+    const { provider, info } = value
+    const { name, uuid, rdns, icon } = info || {}
+
+    const providerExist = !!(provider && EIPUtils.isEIP1193Provider(provider))
+    const infoExist = !!(info && name && uuid && rdns && icon)
+
+    return providerExist && infoExist
+  }
+}

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -4,6 +4,6 @@ export class UnknownNetworkError extends Error {
   }
 }
 
-export interface MetaMaskError extends Error {
+export interface EIP1193Error extends Error {
   code: number
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -2,3 +2,30 @@ export enum WrapFormType {
   WRAP = 'wrap',
   UNWRAP = 'unwrap',
 }
+
+export interface EIP1193Provider {
+  request: <T = object | unknown[], R = unknown>(payload: { method: string; params?: T }) => Promise<R>
+  on: <T = unknown>(eventName: string, callback: (...args: T[]) => void) => this
+  removeListener: <T = unknown>(eventName: string | symbol, listener: (...args: T[]) => void) => this
+}
+
+export enum EIP6963Event {
+  REQUEST_PROVIDER = 'eip6963:requestProvider',
+  ANNOUNCE_PROVIDER = 'eip6963:announceProvider',
+}
+
+export interface EIP6963ProviderInfo {
+  uuid: string
+  name: string
+  icon: string
+  rdns?: string
+}
+
+export interface EIP6963ProviderDetail {
+  info: EIP6963ProviderInfo
+  provider: EIP1193Provider
+}
+
+export interface EIP6963AnnounceProviderEvent {
+  (evt: Event & { detail: EIP6963ProviderDetail }): void
+}


### PR DESCRIPTION
## Solution

Add EIP-6963 support. Each EIP-6963 wallet makes an announcement, which makes it easy to distinguish between different providers. Providers get listed in Select wallet modal.

## Links

Flow here:
- https://www.loom.com/share/1dbfcb1e798f41cfa09c74c43edb6fd0
